### PR TITLE
reset when hitting an error

### DIFF
--- a/bellows/uart.py
+++ b/bellows/uart.py
@@ -145,6 +145,7 @@ class Gateway(asyncio.Protocol):
     def error_frame_received(self, data):
         """Error frame receive handler"""
         LOGGER.debug("Error frame: %s", binascii.hexlify(data))
+        self.reset()
 
     def write(self, data):
         """Send data to the uart"""


### PR DESCRIPTION
Docs say to reset when the NCP is failed.

See "FAILED State" of https://www.silabs.com/documents/public/user-guides/UG101.pdf

The error code I was regularly hitting was `0x51 Error: Exceeded maximum ACK timeout count`

and I hit `0x06 Reset: Assert`