### PR TITLE
Simplify reset

### DIFF
--- a/bellows/uart.py
+++ b/bellows/uart.py
@@ -145,7 +145,7 @@ class Gateway(asyncio.Protocol):
     def error_frame_received(self, data):
         """Error frame receive handler"""
         LOGGER.debug("Error frame: %s", binascii.hexlify(data))
-        self.reset()
+        self.write(self._rst_frame())
 
     def write(self, data):
         """Send data to the uart"""


### PR DESCRIPTION
Not sure why reset can only be called on a new connection, going to dive into it, but want to see what happens first